### PR TITLE
ubidy-commentssocketapi to 0.1.29

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -31,3 +31,6 @@ dependencies:
 - name: ubidy-applicationlookupapi
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.146
+- name: ubidy-commentssocketapi
+  repository: http://jenkins-x-chartmuseum:8080
+  version: 0.1.29


### PR DESCRIPTION
Promote ubidy-commentssocketapi to version 0.1.29