### PR TITLE
ubidy-messagequeueapi to 0.1.50

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -54,4 +54,4 @@ dependencies:
   version: 0.1.45
 - name: ubidy-messagequeueapi
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.1.48
+  version: 0.1.50


### PR DESCRIPTION
Promote ubidy-messagequeueapi to version 0.1.50